### PR TITLE
feat(doc) fix "integrate top bar buttons" heading

### DIFF
--- a/doc/website/docs/integrate-top-bar.md
+++ b/doc/website/docs/integrate-top-bar.md
@@ -3,7 +3,7 @@ id: integrate-top-bar
 title: Top bar buttons
 ---
 
-#Integrate top bar buttons
+# Integrate top bar buttons
 
 As you can see on [the reference site](https://vincent-cotro.welovedevs.com), we've integrated two buttons in the header.
 This can be done via the `additionalNodes.banner.actionButton` props


### PR DESCRIPTION
Hi 👋,

I was looking at the docs and found the heading "Integrate top bar buttons" not being formatted with markdown:
![imagem](https://user-images.githubusercontent.com/18630253/82730175-be30a100-9cf5-11ea-8399-8b03487215d9.png)
