### PR TITLE
Allow i18n overrides

### DIFF
--- a/src/package/components/profile.jsx
+++ b/src/package/components/profile.jsx
@@ -161,7 +161,7 @@ const WithProvidersDeveloperProfile = ({
     const builtTheme = useMemo(() => buildTheme(customization?.theme), [customization?.theme]);
 
     const providerMessages = useMemo(
-        () => ({ ...(parentIntl?.messages || {}), ...(messages[locale] || messages.en) }),
+        () => ({ ...(messages[locale] || messages.en), ...(parentIntl?.messages || {}) }),
         [parentIntl, locale]
     );
 


### PR DESCRIPTION
This change allows an external IntlProvider to override the default messages used by the project.

Context: I'm using this project to build my professional website by integrating it into a create-react-app typescript project (https://github.com/dmcwhorter/resume).  I'd like to be able to override some of the default text built into the project.  Right now I'm building a custom version of react-ultimate-resume just for this one line change, if you all think it would be useful for others I'd like to contribute it back and keep in sync with the releases of the project.