### PR TITLE
Updated package.json  --added options for ssl

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "module": "dist/esm/index.js",
     "types": "dist/cjs/package/index.d.ts",
     "scripts": {
-        "start": "cross-env NODE_ENV=local react-scripts start",
+        "start": "cross-env NODE_ENV=local react-scripts --openssl-legacy-provider start",
         "dev": "yarn start",
         "eject": "react-scripts eject",
         "test": "react-scripts test",


### PR DESCRIPTION
the --openssl-legacy-provider flag is used to specify the OpenSSL provider for legacy versions.

This flag specifically refers to the provider for OpenSSL library. When you use this flag, you are explicitly selecting a legacy provider for OpenSSL